### PR TITLE
fix: useRouteBaseName composable does not return function

### DIFF
--- a/packages/vue-i18n-routing/src/composables/routing.ts
+++ b/packages/vue-i18n-routing/src/composables/routing.ts
@@ -45,30 +45,47 @@ function proxyForComposable<T extends Function>(options: I18nCommonRoutingOption
 }
 
 /**
- * The `useRouteBaseName` composable returns the route base name.
+ * The function that resolves the route base name.
  *
  * @remarks
- * The `useRouteBaseName` is the composable function which is {@link getRouteBaseName} wrapper.
+ * The parameter signatures of this function is the same as {@link getRouteBaseName}.
  *
- * @param givenRoute - A route object. if not provided, the route is returned with `useRoute` will be used internally
- * @param options - An options, which has `router` and `routesNameSeparator` fields. see about details {@link I18nCommonRoutingOptionsWithComposable} for these option fields.
+ * @param givenRoute - A route location. The path or name of the route or an object for more complex routes.
  *
  * @returns The route base name, if route name is not defined, return `null`.
  *
- * @see {@link getRouteBaseName}
+ * @see {@link useRouteBaseName}
  *
  * @public
  */
-export function useRouteBaseName(
-  givenRoute: Route | RouteLocationNormalizedLoaded = useRoute(),
-  { router = useRouter(), routesNameSeparator = undefined }: I18nCommonRoutingOptionsWithComposable = {}
-) {
-  const proxy = {
-    router,
-    route: givenRoute,
-    routesNameSeparator
-  }
-  return getRouteBaseName.call(proxy as any, givenRoute) // eslint-disable-line @typescript-eslint/no-explicit-any
+export type RouteBaseNameFunction = (givenRoute?: Route | RouteLocationNormalizedLoaded) => string | undefined
+
+/**
+ * The `useRouteBaseName` composable returns a function which returns the route base name.
+ *
+ * @remarks
+ * The function returned by `useRouteBaseName` is the wrapper function with the same signature as {@link getRouteBaseName}.
+ *
+ * @param options - An options see about details {@link I18nCommonRoutingOptionsWithComposable}.
+ *
+ * @returns A {@link RouteBaseNameFunction}.
+ *
+ * @public
+ */
+export function useRouteBaseName({
+  router = useRouter(),
+  route = useRoute(),
+  i18n = useI18n(),
+  defaultLocale = undefined,
+  defaultLocaleRouteNameSuffix = undefined,
+  routesNameSeparator = undefined,
+  strategy = undefined,
+  trailingSlash = undefined
+}: I18nCommonRoutingOptionsWithComposable = {}): RouteBaseNameFunction {
+  return proxyForComposable<RouteBaseNameFunction>(
+    { router, route, i18n, defaultLocale, defaultLocaleRouteNameSuffix, routesNameSeparator, strategy, trailingSlash },
+    getRouteBaseName
+  )
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Changes `useRouteBaseName` composable to return a function which can be used to get the route base name, preventing `useRoute` and `useRouter` invocation on every call. More info here See https://github.com/nuxt-modules/i18n/issues/1862

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
https://github.com/nuxt-modules/i18n/issues/1862

### Additional context
I tried to keep the changes consistent with the other code and JSDoc comments, please let me know if additional changes are required.
<!-- e.g. is there anything you'd like reviewers to focus on? -->
