### PR TITLE
fix: cannot extend composer and vue-i18n instance

### DIFF
--- a/packages/vue-i18n-routing/src/extends/i18n.ts
+++ b/packages/vue-i18n-routing/src/extends/i18n.ts
@@ -263,9 +263,5 @@ function extendVueI18n(vueI18n: VueI18n, hook?: ExtendVueI18nHook): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isPluginOptions(options: any): options is VueI18nRoutingPluginOptions {
-  return (
-    isObject(options) &&
-    ('inject' in options || '__composerExtend' in options || '__vueI18nExtend' in options) &&
-    isBoolean(options.inject)
-  )
+  return isObject(options) && ('inject' in options || '__composerExtend' in options || '__vueI18nExtend' in options)
 }

--- a/packages/vue-i18n-routing/src/extends/i18n.ts
+++ b/packages/vue-i18n-routing/src/extends/i18n.ts
@@ -1,4 +1,4 @@
-import { isBoolean, isObject, isFunction, assign } from '@intlify/shared'
+import { isObject, isFunction, assign } from '@intlify/shared'
 import { ref, computed, watch, isVue3, effectScope, isVue2 } from 'vue-demi'
 
 import {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
A bug in isPluginOptions is causing the issue at nuxt/i18n.

### Linked Issues

ref https://github.com/nuxt-modules/i18n/issues/1857

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
