### PR TITLE
fix: route resolve loses query parameters

### DIFF
--- a/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
+++ b/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
@@ -97,6 +97,13 @@ describe('localePath', () => {
           assert.equal(vm.localePath({ state: { foo: 1 } }), '/en')
           await router.push('/ja')
           assert.equal(vm.localePath({ state: { foo: 1 } }), '/ja')
+
+          // preserve query parameters
+          assert.equal(vm.localePath({ query: { foo: 1 } }), '/ja?foo=1')
+          assert.equal(vm.localePath({ path: '/', query: { foo: 1 } }), '/ja?foo=1')
+          assert.equal(vm.localePath({ name: 'about', query: { foo: 1 } }), '/ja/about?foo=1')
+          assert.equal(vm.localePath({ path: '/about', query: { foo: 1 } }), '/ja/about?foo=1')
+
           // no define path
           assert.equal(vm.localePath('/vue-i18n'), '/ja/vue-i18n')
           // no define name

--- a/packages/vue-i18n-routing/src/compatibles/utils.ts
+++ b/packages/vue-i18n-routing/src/compatibles/utils.ts
@@ -79,9 +79,9 @@ export function resolve(router: Router | VueRouter, route: any, strategy: Strate
     if (_route == null) {
       return route
     } else {
-      const _resolevableRoute = assign({}, _route)
-      _resolevableRoute.path = targetPath
-      return router.resolve(_resolevableRoute)
+      const _resolvableRoute = assign({}, route, _route)
+      _resolvableRoute.path = targetPath
+      return router.resolve(_resolvableRoute)
     }
   } else {
     return router.resolve(route)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Fixes `resolve` losing query parameters when passing a route object, tests have also been added to test this behavior. This PR changes `resolve` to merge the resolved route into the passed route.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
https://github.com/nuxt-modules/i18n/issues/2020
https://github.com/nuxt-modules/i18n/issues/1967
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
