### PR TITLE
Do not ignore query params in the `switchLocalePath` method

### DIFF
--- a/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
+++ b/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
@@ -425,6 +425,11 @@ describe('switchLocalePath', () => {
       assert.equal(vm.switchLocalePath('en'), '/en/category/english')
       assert.equal(vm.switchLocalePath('fr'), '/fr/category/franch')
 
+      await router.push('/ja/category/1?page=2')
+      assert.equal(vm.switchLocalePath('ja'), '/ja/category/japanese?page=2')
+      assert.equal(vm.switchLocalePath('en'), '/en/category/english?page=2')
+      assert.equal(vm.switchLocalePath('fr'), '/fr/category/franch?page=2')
+
       await router.push('/ja/foo')
       assert.equal(vm.switchLocalePath('ja'), '/ja/not-found-japanese')
       assert.equal(vm.switchLocalePath('en'), '/en/not-found-english')

--- a/packages/vue-i18n-routing/src/compatibles/routing.ts
+++ b/packages/vue-i18n-routing/src/compatibles/routing.ts
@@ -295,7 +295,7 @@ export function switchLocalePath(this: RoutingProxy, locale: Locale): string {
   const { switchLocalePathIntercepter, dynamicRouteParamsKey } = getI18nRoutingOptions(this.router, this)
 
   // prettier-ignore
-  const { params, ...routeCopy } = isVue3
+  const { params, query, ...routeCopy } = isVue3
     ? (route as RouteLocationNormalizedLoaded) // for vue-router v4
     : isRef<Route>(route) // for vue-router v3
       ? route.value
@@ -308,7 +308,8 @@ export function switchLocalePath(this: RoutingProxy, locale: Locale): string {
     params: {
       ...params,
       ...langSwitchParams
-    }
+    },
+    query
   }
   if (isVue2) {
     _baseRoute.params[0] = params.pathMatch


### PR DESCRIPTION
### Description

Method `switchLocalePath` ignores query params. This improvement allows to not ignore them