### PR TITLE
fix: `resolveRoute` losing query parameters for `string` routes

### DIFF
--- a/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
+++ b/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
@@ -103,6 +103,9 @@ describe('localePath', () => {
           assert.equal(vm.localePath({ path: '/', query: { foo: 1 } }), '/ja?foo=1')
           assert.equal(vm.localePath({ name: 'about', query: { foo: 1 } }), '/ja/about?foo=1')
           assert.equal(vm.localePath({ path: '/about', query: { foo: 1 } }), '/ja/about?foo=1')
+          assert.equal(vm.localePath('/?foo=1'), '/ja?foo=1')
+          assert.equal(vm.localePath('/about?foo=1'), '/ja/about?foo=1')
+          assert.equal(vm.localePath('/about?foo=1&test=2'), '/ja/about?foo=1&test=2')
 
           // no define path
           assert.equal(vm.localePath('/vue-i18n'), '/ja/vue-i18n')
@@ -419,6 +422,11 @@ describe('switchLocalePath', () => {
       assert.equal(vm.switchLocalePath('en'), '/en/about')
       assert.equal(vm.switchLocalePath('fr'), '/fr/about')
       assert.equal(vm.switchLocalePath('vue-i18n'), '')
+
+      await router.push('/ja/about?foo=1&test=2')
+      assert.equal(vm.switchLocalePath('ja'), '/ja/about?foo=1&test=2')
+      assert.equal(vm.switchLocalePath('fr'), '/fr/about?foo=1&test=2')
+      assert.equal(vm.switchLocalePath('en'), '/en/about?foo=1&test=2')
 
       await router.push('/ja/category/1')
       assert.equal(vm.switchLocalePath('ja'), '/ja/category/japanese')

--- a/packages/vue-i18n-routing/src/compatibles/routing.ts
+++ b/packages/vue-i18n-routing/src/compatibles/routing.ts
@@ -165,7 +165,9 @@ export function resolveRoute(this: RoutingProxy, route: any, locale?: Locale): a
   if (isString(route)) {
     if (_route[0] === '/') {
       // if route parameter is a path, create route object with path.
-      _route = { path: route }
+      const [path, search] = route.split('?')
+      const query = Object.fromEntries(new URLSearchParams(search))
+      _route = { path, query }
     } else {
       // else use it as route name.
       _route = { name: route }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Instead of treating `_route` of type `string` as a `{ path: _route }`, the route is split by `?` and the query parameters are converted into an object to be used later in resolution.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Fixes #42 
Downstream https://github.com/nuxt-modules/i18n/issues/2020


