### PR TITLE
fix: switch locale path loses query parameters

### DIFF
--- a/packages/vue-i18n-routing/src/compatibles/routing.ts
+++ b/packages/vue-i18n-routing/src/compatibles/routing.ts
@@ -5,7 +5,7 @@ import { isVue3, isRef, unref, isVue2 } from 'vue-demi'
 import { DEFAULT_DYNAMIC_PARAMS_KEY } from '../constants'
 import { getLocale, getLocaleRouteName, getRouteName } from '../utils'
 
-import { getI18nRoutingOptions, resolve } from './utils'
+import { getI18nRoutingOptions, resolve, routeToObject } from './utils'
 
 import type { RoutingProxy, PrefixableOptions, SwitchLocalePathIntercepter } from './types'
 import type { Strategies, I18nRoutingOptions } from '../types'
@@ -298,23 +298,24 @@ export function switchLocalePath(this: RoutingProxy, locale: Locale): string {
   const { switchLocalePathIntercepter, dynamicRouteParamsKey } = getI18nRoutingOptions(this.router, this)
 
   // prettier-ignore
-  const { params, ...routeCopy } = isVue3
+  const routeValue = isVue3
     ? (route as RouteLocationNormalizedLoaded) // for vue-router v4
     : isRef<Route>(route) // for vue-router v3
       ? route.value
       : route
+  const routeCopy = routeToObject(routeValue)
   const langSwitchParams = getLocalizableMetaFromDynamicParams(route, dynamicRouteParamsKey)[locale] || {}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const _baseRoute: any = {
     name,
     params: {
-      ...params,
+      ...routeCopy.params,
       ...langSwitchParams
     }
   }
   if (isVue2) {
-    _baseRoute.params[0] = params.pathMatch
+    _baseRoute.params[0] = routeCopy.params.pathMatch
   }
 
   const baseRoute = assign({}, routeCopy, _baseRoute)

--- a/packages/vue-i18n-routing/src/compatibles/utils.ts
+++ b/packages/vue-i18n-routing/src/compatibles/utils.ts
@@ -58,6 +58,11 @@ function split(str: string, index: number) {
   return result
 }
 
+/**
+ * NOTE:
+ * Nuxt route uses a proxy with getters for performance reasons (https://github.com/nuxt/nuxt/pull/21957).
+ * Spreading will result in an empty object, so we make a copy of the route by accessing each getter property by name.
+ */
 export function routeToObject(route: Route | RouteLocationNormalizedLoaded) {
   const { fullPath, query, hash, name, path, params, meta, redirectedFrom, matched } = route
   return {

--- a/packages/vue-i18n-routing/src/compatibles/utils.ts
+++ b/packages/vue-i18n-routing/src/compatibles/utils.ts
@@ -18,7 +18,7 @@ import type { RoutingProxy } from './types'
 import type { I18nRoutingGlobalOptions } from '../extends/router'
 import type { Strategies } from '../types'
 import type { Locale } from '@intlify/vue-i18n-bridge'
-import type { VueRouter, Router } from '@intlify/vue-router-bridge'
+import type { VueRouter, Router, Route, RouteLocationNormalizedLoaded } from '@intlify/vue-router-bridge'
 
 export function getI18nRoutingOptions(
   router: Router | VueRouter,
@@ -56,6 +56,21 @@ export function getI18nRoutingOptions(
 function split(str: string, index: number) {
   const result = [str.slice(0, index), str.slice(index)]
   return result
+}
+
+export function routeToObject(route: Route | RouteLocationNormalizedLoaded) {
+  const { fullPath, query, hash, name, path, params, meta, redirectedFrom, matched } = route
+  return {
+    fullPath,
+    params,
+    query,
+    hash,
+    name,
+    path,
+    meta,
+    matched,
+    redirectedFrom
+  }
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
For some reason `switchLocalePath` is not working as expected in `@nuxtjs/i18n`, after debugging it seems like spreading the route here:
https://github.com/intlify/routing/blob/main/packages/vue-i18n-routing/src/compatibles/routing.ts#L301-L305

Does not work for `@nuxtjs/i18n` or maybe it is a Nuxt related issue, I noticed that the `route` object was a proxy and accessing each property did work. So I added a function to destructure each property by name instead of using a spread operator.

Unfortunately I don't know why the behaviour is like this, and I don't think I can add tests for this case as it may be Nuxt related.

This should resolve https://github.com/nuxt-modules/i18n/issues/2354
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
https://github.com/nuxt-modules/i18n/issues/2354
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
