### PR TITLE
test: prevent local package build cache

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -10,6 +10,9 @@ for PKG in packages/* ; do
   popd > /dev/null
 done
 
+rm -rf ./playground/**/node_modules/vue-i18n-routing
+rm -rf ./playground/**/package-lock.json
+
 # Replace deps
 npx jiti ./scripts/replaceDeps.ts
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
After running `pnpm build` and `./scripts/e2e.sh` the build used in the `playground` projects never gets updated. 

I'm assuming that the lock files prevent the `.tgz` build file from being installed, as well as the already installed package in `node_modules/vue-i18n-routing`. 

So I changed `e2e.sh` to remove these which ensures npm tries to install them properly.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
