### PR TITLE
fix: `localePath` missing hash

### DIFF
--- a/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
+++ b/packages/vue-i18n-routing/src/__test__/compatibles.test.ts
@@ -107,6 +107,7 @@ describe('localePath', () => {
           assert.equal(vm.localePath('/about?foo=1'), '/ja/about?foo=1')
           assert.equal(vm.localePath('/about?foo=1&test=2'), '/ja/about?foo=1&test=2')
 
+          assert.equal(vm.localePath({ path: '/about', hash: '#foo=bar' }), '/ja/about#foo=bar')
           // no define path
           assert.equal(vm.localePath('/vue-i18n'), '/ja/vue-i18n')
           // no define name
@@ -442,6 +443,14 @@ describe('switchLocalePath', () => {
       assert.equal(vm.switchLocalePath('ja'), '/ja/about?foo=b%C3%A4r&four=%E5%9B%9B')
       assert.equal(vm.switchLocalePath('fr'), '/fr/about?foo=b%C3%A4r&four=%E5%9B%9B')
       assert.equal(vm.switchLocalePath('en'), '/en/about?foo=b%C3%A4r&four=%E5%9B%9B')
+
+      await router.push('/ja/about#foo=bar')
+      assert.equal(vm.switchLocalePath('ja'), '/ja/about#foo=bar')
+      assert.equal(vm.switchLocalePath('fr'), '/fr/about#foo=bar')
+      assert.equal(vm.switchLocalePath('en'), '/en/about#foo=bar')
+
+      await router.push('/ja/about?foo=é')
+      assert.equal(vm.switchLocalePath('ja'), '/ja/about?foo=%C3%A9')
 
       await router.push('/ja/category/1')
       assert.equal(vm.switchLocalePath('ja'), '/ja/category/japanese')

--- a/packages/vue-i18n-routing/src/compatibles/utils.ts
+++ b/packages/vue-i18n-routing/src/compatibles/utils.ts
@@ -1,4 +1,5 @@
 import { assign, isArray } from '@intlify/shared'
+import { parsePath } from 'ufo'
 import { isVue3 } from 'vue-demi'
 
 import {
@@ -104,13 +105,14 @@ export function resolveBridgeRoute(val: BridgeRoute) {
 export function resolvedRouteToObject(route: BridgeRoute): BridgeRoute {
   const r = resolveBridgeRoute(route)
 
+  const { search, hash } = parsePath(r.fullPath)
+
   const encodedPath = encodeURI(r.path)
-  const queryString = r.fullPath.indexOf('?') >= 0 ? r.fullPath.substring(r.fullPath.indexOf('?')) : ''
   const resolvedObject = {
     ...r,
-    fullPath: encodedPath + queryString,
+    fullPath: encodedPath + search + hash,
     path: encodedPath,
-    href: encodedPath + queryString
+    href: encodedPath + search + hash
   }
 
   return isVue3 ? resolvedObject : { ...route, route: resolvedObject }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Resolves https://github.com/nuxt-modules/i18n/issues/2525

I believe the hash (as well as query) are being encoded twice (https://github.com/nuxt-modules/i18n/issues/2523), will be looking into that.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
* https://github.com/nuxt-modules/i18n/issues/2525

### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->
