### PR TITLE
feat: dynamic params interceptor

### DIFF
--- a/packages/vue-i18n-routing/src/compatibles/utils.ts
+++ b/packages/vue-i18n-routing/src/compatibles/utils.ts
@@ -41,7 +41,8 @@ export function getI18nRoutingOptions(
     switchLocalePathIntercepter = DefaultSwitchLocalePathIntercepter,
     dynamicRouteParamsKey = DEFAULT_DYNAMIC_PARAMS_KEY
   }: I18nRoutingGlobalOptions = {}
-): Required<I18nRoutingGlobalOptions> {
+): Required<Omit<I18nRoutingGlobalOptions, 'dynamicParamsInterceptor'>> &
+  Pick<I18nRoutingGlobalOptions, 'dynamicParamsInterceptor'> {
   const options = getGlobalOptions(router)
   return {
     defaultLocale: proxy.defaultLocale || options.defaultLocale || defaultLocale,
@@ -55,7 +56,8 @@ export function getI18nRoutingOptions(
     prefixable: proxy.prefixable || options.prefixable || prefixable,
     switchLocalePathIntercepter:
       proxy.switchLocalePathIntercepter || options.switchLocalePathIntercepter || switchLocalePathIntercepter,
-    dynamicRouteParamsKey: proxy.dynamicRouteParamsKey || options.dynamicRouteParamsKey || dynamicRouteParamsKey
+    dynamicRouteParamsKey: proxy.dynamicRouteParamsKey || options.dynamicRouteParamsKey || dynamicRouteParamsKey,
+    dynamicParamsInterceptor: options.dynamicParamsInterceptor || undefined
   }
 }
 

--- a/packages/vue-i18n-routing/src/extends/router.ts
+++ b/packages/vue-i18n-routing/src/extends/router.ts
@@ -27,6 +27,8 @@ import type {
   RouteLocationNormalizedLoaded,
   RouteLocationNormalized
 } from '@intlify/vue-router-bridge'
+import type { Ref } from 'vue-demi'
+import type { Locale } from 'vue-i18n'
 
 /**
  * Global options for i18n routing
@@ -42,8 +44,9 @@ export type I18nRoutingGlobalOptions<Context = unknown> = Pick<
   | 'prefixable'
   | 'switchLocalePathIntercepter'
   | 'dynamicRouteParamsKey'
-> & { localeCodes?: string[] }
+> & { localeCodes?: string[]; dynamicParamsInterceptor?: DynamicParamsInterceptor }
 
+export type DynamicParamsInterceptor = () => Ref<Record<Locale, unknown>>
 const GlobalOptionsRegistory = makeSymbol('vue-i18n-routing-gor')
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/routing/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
* Makes https://github.com/nuxt-modules/i18n/pull/2580 possible

I'm trying to figure out a way to make dynamic params translations work for `@nuxtjs/i18n`, and this may make it possible to do so. 

If the feature/fix for `@nuxtjs/i18n` does work, I want to look into replacing the head tag management in this repo with `unhead`. https://github.com/nuxt-modules/i18n/pull/2580 copies and changes `useLocaleHead` to use the `unhead` instance, it would be more ideal to change the code here to make it more compatible instead.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
