### PR TITLE
fix: augment vue rather than sub packages

### DIFF
--- a/packages/vue-i18n-routing/src/vue.d.ts
+++ b/packages/vue-i18n-routing/src/vue.d.ts
@@ -67,7 +67,7 @@ declare module 'vue/types/vue' {
   export interface Vue extends I18nMixinAPI {}
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface ComponentCustomProperties extends I18nMixinAPI {}
 }


### PR DESCRIPTION
### Description

As mentioned in [#28542](https://github.com/nuxt/nuxt/pull/28542), augmenting `vue` is the proper way to avoid type issues.

### Linked Issues

#96 